### PR TITLE
Boot - Add support for setting Pipewire environment variables and configuring audio settings in Linux

### DIFF
--- a/app/config/user-examples/audio-settings.toml
+++ b/app/config/user-examples/audio-settings.toml
@@ -129,7 +129,7 @@
 # You can modify the pipewire parameters here:
 
 # linux_pipewire_buffsize = 1024
-# linux_pipewire_samplerate = 4800
+# linux_pipewire_samplerate = 48000
 
 
 

--- a/app/config/user-examples/audio-settings.toml
+++ b/app/config/user-examples/audio-settings.toml
@@ -121,6 +121,17 @@
 # num_random_seeds = 64
 
 
+## ===============================
+## Linux Audio - Pipewire settings
+## ===============================
+#
+# Sonic Pi uses pipewire for Audio on Linux
+# You can modify the pipewire parameters here:
+
+# linux_pipewire_buffsize = 1024
+# linux_pipewire_samplerate = 4800
+
+
 
 ## ============
 ## Escape hatch

--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -1156,19 +1156,19 @@ module SonicPi
 
         case Util.os
         when :linux, :raspberry
-          toml_pw_buffsize = toml_opts_hash["linux_pipewire_buffsize"].to_i
-          toml_pw_samplerate = toml_opts_hash["linux_pipewire_samplerate"].to_i
+          toml_pw_buffsize = toml_opts_hash[:linux_pipewire_buffsize].to_i
+          toml_pw_samplerate = toml_opts_hash[:linux_pipewire_samplerate].to_i
           pw_buffsize = 1024
           pw_samplerate = 48000
 
-          if (toml_opts_hash.has_key?("linux_pipewire_buffsize") && (toml_pw_buffsize > 0))
+          if (toml_opts_hash.has_key?(:linux_pipewire_buffsize) && (toml_pw_buffsize > 0))
             Util.log "Setting pipewire buffsize to: #{toml_pw_buffsize}"
             pw_buffsize = toml_pw_buffsize
           else
             Util.log "Using default pipewire buffsize of: 1024"
           end
 
-          if (toml_opts_hash.has_key?("linux_pipewire_samplerate") && (toml_pw_samplerate > 0))
+          if (toml_opts_hash.has_key?(:linux_pipewire_samplerate) && (toml_pw_samplerate > 0))
             Util.log "Setting pipewire samplerate to: #{toml_pw_samplerate}"
             pw_samplerate = toml_pw_samplerate
           else

--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -744,7 +744,8 @@ module SonicPi
 
     class ProcessBooter
       attr_reader :pid, :args, :cmd, :log
-      def initialize(cmd, args, log_path, record_log=false)
+      def initialize(cmd, args, log_path, record_log=false, env=nil)
+        @env = env
         @pid = nil
         @log_file = nil
         @args = args.map {|el| el.to_s}
@@ -786,7 +787,11 @@ module SonicPi
       def boot
         Util.log "Process Booter - booting #{@cmd} with args #{@args.inspect}"
         Util.log "#{@cmd} #{@args.join(' ')}"
-        @stdin, @stdout_and_err, @wait_thr = Open3.popen2e @cmd, *@args
+        if @env
+          @stdin, @stdout_and_err, @wait_thr = Open3.popen2e @env, @cmd, *@args
+        else
+          @stdin, @stdout_and_err, @wait_thr = Open3.popen2e @cmd, *@args
+        end
         @pid = @wait_thr.pid
         if @log_file
           @io_thr = Thread.new do
@@ -1030,7 +1035,6 @@ module SonicPi
       end
     end
 
-
     class JackBooter < ProcessBooter
       def initialize
         cmd = "jackd"
@@ -1134,6 +1138,10 @@ module SonicPi
           toml_opts_hash = {}
         end
 
+        # freeze toml_opts_hash in case any nasty mutation happens below
+        # (oh for immutable data structures by default!)
+        toml_opts_hash.freeze
+
         Util.log "Got Audio Settings toml hash: #{toml_opts_hash.inspect}"
         opts = unify_toml_opts_hash(toml_opts_hash)
         Util.log "Unified Audio Settings toml hash: #{opts.inspect}"
@@ -1145,9 +1153,40 @@ module SonicPi
         @num_outputs = opts["-o"].to_i
         args = opts.to_a.flatten
         cmd = Paths.scsynth_path
+
+        case Util.os
+        when :linux, :raspberry
+          toml_pw_buffsize = toml_opts_hash["linux_pipewire_buffsize"].to_i
+          toml_pw_samplerate = toml_opts_hash["linux_pipewire_samplerate"].to_i
+          pw_buffsize = 1024
+          pw_samplerate = 4800
+
+          if (toml_opts_hash.has_key?("linux_pipewire_buffsize") && (toml_pw_buffsize > 0))
+            Util.log "Setting pipewire buffsize to: #{toml_pw_buffsize}"
+            pw_buffsize = toml_pw_buffsize
+          else
+            Util.log "Using default pipewire buffsize of: 1024"
+          end
+
+          if (toml_opts_hash.has_key?("linux_pipewire_samplerate") && (toml_pw_samplerate > 0))
+            Util.log "Setting pipewire samplerate to: #{toml_pw_samplerate}"
+            pw_samplerate = toml_pw_samplerate
+          else
+            Util.log "Using default pipewire buffsize of: 4800"
+          end
+
+          ld_library_path = `pw-jack /bin/sh -c 'echo $LD_LIBRARY_PATH'`.strip
+          pw_quantum ="#{pw_buffsize}/#{pw_samplerate}"
+
+          Util.log "Starting scsynth with LD_LIBRARY_PATH set to #{ld_library_path.inspect} so it uses pipewire's jack"
+          env = { "PIPEWIRE_QUANTUM" => pw_quantum ,  "LD_LIBRARY_PATH" => ld_library_path }
+        else
+          env = nil
+        end
+
         @success = Promise.new
         run_pre_start_commands
-        super(cmd, args, Paths.scsynth_log_path, true)
+        super(cmd, args, Paths.scsynth_log_path, true, env)
         run_post_start_commands
         success = wait_for_boot
         disable_internal_log_recording!
@@ -1234,7 +1273,7 @@ module SonicPi
           end
         end
       end
-            
+
       def run_post_start_commands
         case Util.os
         when :raspberry, :linux

--- a/app/server/ruby/bin/daemon.rb
+++ b/app/server/ruby/bin/daemon.rb
@@ -1159,7 +1159,7 @@ module SonicPi
           toml_pw_buffsize = toml_opts_hash["linux_pipewire_buffsize"].to_i
           toml_pw_samplerate = toml_opts_hash["linux_pipewire_samplerate"].to_i
           pw_buffsize = 1024
-          pw_samplerate = 4800
+          pw_samplerate = 48000
 
           if (toml_opts_hash.has_key?("linux_pipewire_buffsize") && (toml_pw_buffsize > 0))
             Util.log "Setting pipewire buffsize to: #{toml_pw_buffsize}"
@@ -1172,7 +1172,7 @@ module SonicPi
             Util.log "Setting pipewire samplerate to: #{toml_pw_samplerate}"
             pw_samplerate = toml_pw_samplerate
           else
-            Util.log "Using default pipewire buffsize of: 4800"
+            Util.log "Using default pipewire samplerate of: 48000"
           end
 
           ld_library_path = `pw-jack /bin/sh -c 'echo $LD_LIBRARY_PATH'`.strip


### PR DESCRIPTION
### **User description**
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


___

### **Description**
- Added support for setting Pipewire environment variables and configuring audio settings in Linux environment.
- Introduced a new `env` parameter in the `ProcessBooter` class to handle environment variables.
- Implemented logic to set `PIPEWIRE_QUANTUM` and `LD_LIBRARY_PATH` based on configuration options.
- Updated the initialization method in `JackBooter` class to manage Linux-specific audio settings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>daemon.rb</strong><dd><code>Boot - Add env parameter and set Pipewire env vars</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/server/ruby/bin/daemon.rb
['Added a new `env` parameter to the `ProcessBooter` class constructor', 'Modified the `boot` method to conditionally use the `env` parameter when calling `Open3.popen2e`', 'Added logic to set `PIPEWIRE_QUANTUM` and `LD_LIBRARY_PATH` environment variables based on config options in `audio-settings.toml`', 'Updated the `initialize` method in `JackBooter` class to handle Linux-specific audio settings']


</details>


  </td>
  <td><a href="https://github.com/2lambda123/sonic-pi-net-sonic-pi/pull/1/files#diff-2ca3189a9188d736a9e846057be42fa4b7727274ac6e0152bc0320031f73ad7d">+44/-5</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>audio-settings.toml</strong><dd><code>Add Linux Audio Pipewire settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/config/user-examples/audio-settings.toml
['Added Linux Audio Pipewire settings section', 'Included options to configure `linux_pipewire_buffsize` and `linux_pipewire_samplerate`']


</details>


  </td>
  <td><a href="https://github.com/2lambda123/sonic-pi-net-sonic-pi/pull/1/files#diff-8a168878b1ba752dd3baba106f59bc65bc8a84528d5d4fbdca0207a84aa37da4">+11/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>